### PR TITLE
feat: drop support for node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "author": "GolemFactory <contact@golem.network>",
   "license": "GPL-3.0",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "bugs": {
     "url": "https://github.com/GolemFactory/create-golem-app/issues"


### PR DESCRIPTION
JST-597

BREAKING CHANGE: Node 16 is no longer supported.